### PR TITLE
Fix support for next IP API

### DIFF
--- a/netbox/client/ipam/ip_a_m_prefixes_available_ips_read_responses.go
+++ b/netbox/client/ipam/ip_a_m_prefixes_available_ips_read_responses.go
@@ -61,7 +61,7 @@ func NewIPAMPrefixesAvailableIpsReadOK() *IPAMPrefixesAvailableIpsReadOK {
 IPAMPrefixesAvailableIpsReadOK ipam prefixes available ips read o k
 */
 type IPAMPrefixesAvailableIpsReadOK struct {
-	Payload *models.Prefix
+	Payload *[]models.IPData
 }
 
 func (o *IPAMPrefixesAvailableIpsReadOK) Error() string {
@@ -70,7 +70,7 @@ func (o *IPAMPrefixesAvailableIpsReadOK) Error() string {
 
 func (o *IPAMPrefixesAvailableIpsReadOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Prefix)
+	o.Payload = new([]models.IPData)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/netbox/models/ip_address.go
+++ b/netbox/models/ip_address.go
@@ -577,3 +577,9 @@ func (m *IPAddressStatus) UnmarshalBinary(b []byte) error {
 	*m = res
 	return nil
 }
+
+type IPData struct {
+	Family *int `json:"family,omitempty"`
+	Address *string `json:"address,omitempty"`
+	Vrf *string `json:"vrf,omitempty"`
+}


### PR DESCRIPTION
The schema provided by NetBox for getting a next IP address is
incorrect, which means generated API clients are also incorrect. I
have reported this issue in netbox-community/netbox#3356.